### PR TITLE
Fix/fixes for mobile

### DIFF
--- a/Features/Articles/Services/ArticleService.cs
+++ b/Features/Articles/Services/ArticleService.cs
@@ -63,7 +63,7 @@ public class ArticleService : IArticleService
     public async Task<Result> DeleteArticleAsync(Guid id, ClaimsPrincipal context,
         CancellationToken cancellationToken = default)
     {
-        var existing = await _repository.FindAsync(id, cancellationToken);
+        var existing = await _repository.GetArticle(id, cancellationToken);
         if (existing == null) return Result.Failure<ReturnArticleDto>("Article not found");
 
         var authResult = AuthorizationUtils.IsAdminOrOwner(existing.Ressource.UserId, context, cancellationToken);

--- a/Features/Events/Services/EventService.cs
+++ b/Features/Events/Services/EventService.cs
@@ -78,14 +78,14 @@ public class EventService : IEventService
         if (eventToDelete is null)
             return Result.Failure("Event not found");
 
-        var ressourceToDelete = await _ressourceRepository.FirstOrDefaultAsync(r => r.Id == eventToDelete.RessourceId, token);
-
-        if (ressourceToDelete is null)
-            return Result.Failure("Ressource not found");
+        var ressourceId = eventToDelete.RessourceId;
 
         await _eventRepository.RemoveAllMembersAsync(eventId, token);
         await _eventRepository.DeleteAsync(eventToDelete, token);
-        await _ressourceRepository.DeleteAsync(ressourceToDelete, token);
+
+        var ressourceToDelete = await _ressourceRepository.FirstOrDefaultAsync(r => r.Id == ressourceId, token);
+        if (ressourceToDelete is not null)
+            await _ressourceRepository.DeleteAsync(ressourceToDelete, token);
 
         return Result.Success();
     }

--- a/Features/Polls/Repositories/PollRepository.cs
+++ b/Features/Polls/Repositories/PollRepository.cs
@@ -36,6 +36,7 @@ public class PollRepository : BaseRepository<Poll>, IPollRepository
             .Include(p => p.Ressource)
                 .ThenInclude(r => r.Tags)
             .Include(p => p.PollsOptions)
+            .AsSingleQuery()
             .Skip((query.page - 1) * query.size)
             .Take(query.size)
             .ToListAsync(cancellationToken);
@@ -59,6 +60,7 @@ public class PollRepository : BaseRepository<Poll>, IPollRepository
             .Include(p => p.Ressource)
                 .ThenInclude(r => r.Tags)
             .Include(p => p.PollsOptions)
+            .AsSingleQuery()
             .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
     }
 
@@ -76,6 +78,7 @@ public class PollRepository : BaseRepository<Poll>, IPollRepository
             .Include(p => p.Ressource)
                 .ThenInclude(r => r.Tags)
             .Include(p => p.PollsOptions)
+            .AsSingleQuery()
             .FirstOrDefaultAsync(p => p.RessourceId == ressourceId, cancellationToken);
     }
 }

--- a/Features/Ressources/Services/RessourceService.cs
+++ b/Features/Ressources/Services/RessourceService.cs
@@ -54,25 +54,22 @@ public class RessourceService : IRessourceService
             ressourceQuery.RessourceTitle is not null)
             return await _repository.PaginatedRessourcesAsync(ressourceQuery, cancellationToken);
 
-        var isComplete = true;
-
         var cacheKey = $"ressources:p={ressourceQuery.page}:s={ressourceQuery.size}";
-        var incompleteRessources = new List<string> { "ressources:incompletePage" };
-        var completeRessources = new List<string> { "ressources:completePage" };
         var entryOptions = new HybridCacheEntryOptions();
+
+        PaginatedList<ReturnRessourceDto>? freshRessources = null;
 
         var ressources = await _cache.GetOrCreateAsync(cacheKey, async _ =>
             {
-                var ressources = await _repository.PaginatedRessourcesAsync(ressourceQuery, cancellationToken);
-                isComplete = ressources.Items.Count == ressourceQuery.size;
-
-                await RessourceCacheHandler(ressources, ressourceQuery, cacheKey);
-
-                return ressources;
+                freshRessources = await _repository.PaginatedRessourcesAsync(ressourceQuery, cancellationToken);
+                return freshRessources;
             },
             entryOptions,
-            isComplete ? completeRessources : incompleteRessources,
+            ["ressources:completePage"],
             cancellationToken);
+
+        if (freshRessources is not null)
+            await RessourceCacheHandler(freshRessources, ressourceQuery, cacheKey);
 
         return ressources;
     }


### PR DESCRIPTION
J'ai chié sur les commits donc je décris ici mes bb d'amour :
ArticleService => Récupération de l'entité ressource pour éviter d'avoir existing.Ressource.UserId null pour le DeleteArticleAsync

EventService => Pour DeleteEventAsync on sauvegarde l'id de la ressource avant RemoveAllMembersAsync, comme ça on supprime l'event en premier puis la ressource et on évite les conflits avec les tracking d'entités

PollRepository => Ajout de AsSingleQuery() pour éviter d'avoir des split queries qui cause une erreur ArgumentOutOfRangeException (Npgsql)

RessourceService => Le cache handler est appelé que quand le cahche a finis d'écrire ça évite des appels HybirdCache imbriqués, et donc d'avoir des instances de DbContext concurrentes en plus